### PR TITLE
Add skeleton DataFrame query assistant

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,51 @@
+# Product Requirements Document (PRD)
+
+## Project: Dynamic DataFrame Query Assistant with RAG Evaluation
+
+### Overview
+This tool provides a GUI (built with Streamlit) to query uploaded CSV or Excel
+files via standard or custom pandas filters. The query results are rendered
+through user-defined templates and compared with Retrieval Augmented Generation
+(RAG) answers. Users can manage templates and test cases directly from the UI.
+The code base is modular to encourage customization and extension.
+
+### Functional Requirements
+1. **Data Input**
+   - Upload CSV or Excel files to create pandas DataFrames.
+   - Support multiple filters on columns and optional custom filter functions.
+   - Allow execution of DataFrame code snippets in a controlled environment.
+
+2. **Answer Generation**
+   - Render answers using message templates with variables from pandas queries.
+   - Templates handle scalars and lists via Jinja2 style syntax.
+
+3. **RAG Comparison**
+   - Generate alternative answers via a RAG module.
+   - Display similarity metrics between DataFrame answers and RAG answers.
+
+4. **Template Management**
+   - Create, edit, and delete templates in the GUI.
+   - Templates persist to a JSON file for reuse.
+
+5. **Test Case Generation & Management**
+   - After evaluation, a **Save as Test Case** button stores the question,
+     filter configuration or custom code, template, and resulting answer.
+   - Test cases can be duplicated from the UI for similar questions.
+   - A dedicated tab lists all test cases allowing view, edit, and delete.
+   - Test cases are stored in a structured JSON file for version control.
+
+### Non-Functional Requirements
+- **Usability:** The GUI should be intuitive with clear labels and tooltips.
+- **Extensibility & Modularity:** Separate modules for data handling,
+  filtering, templating, and UI allow easy customization.
+- **Performance:** Operations on DataFrames up to 1GB should remain responsive
+  with progress indicators for long tasks.
+- **Security:** Code execution must be sandboxed (e.g., via Docker) to protect
+  the host environment.
+- **Statefulness:** The application retains state during a user session
+  including loaded data, filters, and custom code.
+
+### Future Enhancements
+- Export evaluation reports.
+- Multi-language template support.
+- Integration with version control for templates and tests.

--- a/df_assistant/app.py
+++ b/df_assistant/app.py
@@ -3,13 +3,18 @@ import pandas as pd
 
 from filter_engine import apply_standard_filters, apply_custom_filter
 from template_engine import render_template
+from template_manager import (
+    load_templates,
+    add_or_update_template,
+    delete_template,
+)
 from rag_module import get_rag_answer
 from evaluation import similarity
 from test_manager import add_test
 
 
 def main():
-    st.title("DataFrame Query Assistant")
+    st.title("Dynamic DataFrame Query Assistant")
 
     uploaded = st.file_uploader("Upload CSV or Excel")
     if uploaded:
@@ -52,9 +57,38 @@ def main():
         st.subheader("Query Result")
         st.write(df_filtered)
 
-        template = st.text_area("Message Template", "There are {{ count }} records.")
+        # Template management
+        templates = load_templates()
+        template_names = list(templates.keys())
+        new_option = "<New Template>"
+        selected = st.selectbox("Choose Template", template_names + [new_option])
+        if selected != new_option:
+            template_name = selected
+            template_content = templates[selected]
+        else:
+            template_name = st.text_input("Template Name")
+            template_content = ""
+
+        template = st.text_area("Message Template", template_content, key="tmpl")
+
+        col_save, col_delete = st.columns(2)
+        if col_save.button("Save Template"):
+            if template_name:
+                add_or_update_template(template_name, template)
+                st.success("Template saved")
+            else:
+                st.error("Template name required")
+
+        if selected != new_option and col_delete.button("Delete Template"):
+            delete_template(template_name)
+            st.success("Template deleted")
+
         if st.button("Generate Answer"):
-            context = {"count": len(df_filtered), "rows": df_filtered.to_dict(orient="records")}
+            context = {
+                "count": len(df_filtered),
+                "rows": df_filtered.to_dict(orient="records"),
+                "result": df_filtered,
+            }
             answer = render_template(template, context)
             st.write("Answer:", answer)
 

--- a/df_assistant/app.py
+++ b/df_assistant/app.py
@@ -1,0 +1,73 @@
+import streamlit as st
+import pandas as pd
+
+from filter_engine import apply_standard_filters, apply_custom_filter
+from template_engine import render_template
+from rag_module import get_rag_answer
+from evaluation import similarity
+from test_manager import add_test
+
+
+def main():
+    st.title("DataFrame Query Assistant")
+
+    uploaded = st.file_uploader("Upload CSV or Excel")
+    if uploaded:
+        if uploaded.name.endswith(".csv"):
+            df = pd.read_csv(uploaded)
+        else:
+            df = pd.read_excel(uploaded)
+        st.write("Data Loaded", df.head())
+
+        filters = {}
+        for col in df.columns:
+            if st.checkbox(f"Filter by {col}"):
+                if pd.api.types.is_numeric_dtype(df[col]):
+                    low = st.number_input(f"{col} min", value=float(df[col].min()))
+                    high = st.number_input(f"{col} max", value=float(df[col].max()))
+                    filters[col] = (low, high)
+                else:
+                    value = st.text_input(f"{col} value")
+                    if value:
+                        filters[col] = value
+
+        if st.text_area("Custom Filter Function", key="custom_func"):
+            code = st.session_state["custom_func"]
+            try:
+                # dangerously evaluate user code in a local scope
+                local_vars = {}
+                exec(code, {}, local_vars)
+                func = local_vars.get("filter_func")
+                if func:
+                    df_filtered = apply_custom_filter(df, func)
+                else:
+                    st.error("Define a function named filter_func")
+                    return
+            except Exception as exc:
+                st.error(f"Custom filter error: {exc}")
+                return
+        else:
+            df_filtered = apply_standard_filters(df, filters)
+
+        st.subheader("Query Result")
+        st.write(df_filtered)
+
+        template = st.text_area("Message Template", "There are {{ count }} records.")
+        if st.button("Generate Answer"):
+            context = {"count": len(df_filtered), "rows": df_filtered.to_dict(orient="records")}
+            answer = render_template(template, context)
+            st.write("Answer:", answer)
+
+            question = st.text_input("Question", "")
+            rag_answer = get_rag_answer(question)
+            st.write("RAG Answer:", rag_answer)
+            score = similarity(answer, rag_answer)
+            st.write(f"Similarity: {score:.2f}")
+
+            if st.button("Save as Test Case"):
+                add_test({"question": question, "filters": filters, "template": template, "expected": answer})
+                st.success("Test case saved")
+
+
+if __name__ == "__main__":
+    main()

--- a/df_assistant/app.py
+++ b/df_assistant/app.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import pandas as pd
+import json
 
 from filter_engine import apply_standard_filters, apply_custom_filter
 from template_engine import render_template
@@ -10,19 +11,28 @@ from template_manager import (
 )
 from rag_module import get_rag_answer
 from evaluation import similarity
-from test_manager import add_test
+from test_manager import (
+    add_test,
+    load_tests,
+    update_test,
+    delete_test,
+    duplicate_test,
+)
 
 
 def main():
     st.title("Dynamic DataFrame Query Assistant")
 
-    uploaded = st.file_uploader("Upload CSV or Excel")
-    if uploaded:
-        if uploaded.name.endswith(".csv"):
-            df = pd.read_csv(uploaded)
-        else:
-            df = pd.read_excel(uploaded)
-        st.write("Data Loaded", df.head())
+    tabs = st.tabs(["Query", "Test Cases"])
+
+    with tabs[0]:
+        uploaded = st.file_uploader("Upload CSV or Excel")
+        if uploaded:
+            if uploaded.name.endswith(".csv"):
+                df = pd.read_csv(uploaded)
+            else:
+                df = pd.read_excel(uploaded)
+            st.write("Data Loaded", df.head())
 
         filters = {}
         for col in df.columns:
@@ -99,8 +109,52 @@ def main():
             st.write(f"Similarity: {score:.2f}")
 
             if st.button("Save as Test Case"):
-                add_test({"question": question, "filters": filters, "template": template, "expected": answer})
+                add_test({
+                    "question": question,
+                    "filters": filters,
+                    "custom_code": st.session_state.get("custom_func", ""),
+                    "template": template,
+                    "expected": answer,
+                })
                 st.success("Test case saved")
+
+    with tabs[1]:
+        st.subheader("Saved Test Cases")
+        tests = load_tests()
+        for i, test in enumerate(tests):
+            with st.expander(f"Test {i+1}: {test.get('question', '')}"):
+                q = st.text_input("Question", test.get("question", ""), key=f"q_{i}")
+                filters_text = st.text_area(
+                    "Filters (JSON)",
+                    json.dumps(test.get("filters", {}), indent=2),
+                    key=f"f_{i}",
+                )
+                code = st.text_area(
+                    "Custom Code",
+                    test.get("custom_code", ""),
+                    key=f"c_{i}",
+                )
+                tmpl = st.text_area("Template", test.get("template", ""), key=f"t_{i}")
+                expected = st.text_area("Expected", test.get("expected", ""), key=f"e_{i}")
+                col_u, col_d, col_dup = st.columns(3)
+                if col_u.button("Update", key=f"update_{i}"):
+                    update_test(
+                        i,
+                        {
+                            "question": q,
+                            "filters": json.loads(filters_text or "{}"),
+                            "custom_code": code,
+                            "template": tmpl,
+                            "expected": expected,
+                        },
+                    )
+                    st.experimental_rerun()
+                if col_d.button("Delete", key=f"delete_{i}"):
+                    delete_test(i)
+                    st.experimental_rerun()
+                if col_dup.button("Duplicate", key=f"dup_{i}"):
+                    duplicate_test(i)
+                    st.experimental_rerun()
 
 
 if __name__ == "__main__":

--- a/df_assistant/evaluation.py
+++ b/df_assistant/evaluation.py
@@ -1,0 +1,6 @@
+from difflib import SequenceMatcher
+
+
+def similarity(a: str, b: str) -> float:
+    """Return a similarity ratio between two strings."""
+    return SequenceMatcher(None, a, b).ratio()

--- a/df_assistant/filter_engine.py
+++ b/df_assistant/filter_engine.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from typing import Callable, Dict, Any
+
+
+def apply_standard_filters(df: pd.DataFrame, filters: Dict[str, Any]) -> pd.DataFrame:
+    """Apply simple equality or range filters."""
+    for column, condition in filters.items():
+        if isinstance(condition, tuple) and len(condition) == 2:
+            low, high = condition
+            df = df[(df[column] >= low) & (df[column] <= high)]
+        else:
+            df = df[df[column] == condition]
+    return df
+
+
+def apply_custom_filter(df: pd.DataFrame, func: Callable[[pd.DataFrame], pd.DataFrame]) -> pd.DataFrame:
+    """Apply a user-defined filter function."""
+    try:
+        return func(df)
+    except Exception as exc:
+        raise ValueError(f"Error in custom filter: {exc}")

--- a/df_assistant/rag_module.py
+++ b/df_assistant/rag_module.py
@@ -1,0 +1,7 @@
+"""Placeholder RAG implementation."""
+from typing import Any
+
+
+def get_rag_answer(question: str) -> str:
+    # In a real implementation, call an external RAG service
+    return f"RAG answer for: {question}"

--- a/df_assistant/template_engine.py
+++ b/df_assistant/template_engine.py
@@ -1,7 +1,22 @@
+"""Utility for rendering answer templates."""
+
 from typing import Any, Dict
 from jinja2 import Template
+import pandas as pd
 
 
 def render_template(template_str: str, context: Dict[str, Any]) -> str:
+    """Render a Jinja2 template with the given context.
+
+    The context may include scalars, lists, or pandas objects. DataFrames are
+    passed directly so templates can iterate over ``result`` or call methods
+    such as ``to_markdown``.
+    """
+
+    # Convert Series to list for convenience
+    for key, value in list(context.items()):
+        if isinstance(value, pd.Series):
+            context[key] = value.tolist()
+
     template = Template(template_str)
     return template.render(**context)

--- a/df_assistant/template_engine.py
+++ b/df_assistant/template_engine.py
@@ -1,0 +1,7 @@
+from typing import Any, Dict
+from jinja2 import Template
+
+
+def render_template(template_str: str, context: Dict[str, Any]) -> str:
+    template = Template(template_str)
+    return template.render(**context)

--- a/df_assistant/template_manager.py
+++ b/df_assistant/template_manager.py
@@ -1,0 +1,31 @@
+import json
+from typing import Dict
+
+TEMPLATES_FILE = "templates.json"
+
+
+def load_templates() -> Dict[str, str]:
+    """Return a dictionary of template_name -> template_string."""
+    try:
+        with open(TEMPLATES_FILE, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def save_templates(templates: Dict[str, str]):
+    with open(TEMPLATES_FILE, "w") as f:
+        json.dump(templates, f, indent=2)
+
+
+def add_or_update_template(name: str, template: str):
+    templates = load_templates()
+    templates[name] = template
+    save_templates(templates)
+
+
+def delete_template(name: str):
+    templates = load_templates()
+    if name in templates:
+        templates.pop(name)
+        save_templates(templates)

--- a/df_assistant/test_manager.py
+++ b/df_assistant/test_manager.py
@@ -1,0 +1,23 @@
+import json
+from typing import Dict, Any, List
+
+TEST_FILE = "tests.json"
+
+
+def load_tests() -> List[Dict[str, Any]]:
+    try:
+        with open(TEST_FILE, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return []
+
+
+def save_tests(tests: List[Dict[str, Any]]):
+    with open(TEST_FILE, "w") as f:
+        json.dump(tests, f, indent=2)
+
+
+def add_test(test: Dict[str, Any]):
+    tests = load_tests()
+    tests.append(test)
+    save_tests(tests)

--- a/df_assistant/test_manager.py
+++ b/df_assistant/test_manager.py
@@ -21,3 +21,24 @@ def add_test(test: Dict[str, Any]):
     tests = load_tests()
     tests.append(test)
     save_tests(tests)
+
+
+def update_test(index: int, test: Dict[str, Any]):
+    tests = load_tests()
+    if 0 <= index < len(tests):
+        tests[index] = test
+        save_tests(tests)
+
+
+def delete_test(index: int):
+    tests = load_tests()
+    if 0 <= index < len(tests):
+        tests.pop(index)
+        save_tests(tests)
+
+
+def duplicate_test(index: int):
+    tests = load_tests()
+    if 0 <= index < len(tests):
+        tests.append(tests[index].copy())
+        save_tests(tests)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+jinja2


### PR DESCRIPTION
## Summary
- create Streamlit app for DataFrame query assistant
- add modules for filters, templating, RAG, evaluation and tests
- include lightweight test case management and dependencies

## Testing
- `python3 -m py_compile df_assistant/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685c65847070832b8a1ed7a9a18ab911